### PR TITLE
Downgrade Unity Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ And some code snippets from the archived [dear-imgui-unity](https://github.com/r
   - ✅ Linux
   - ✅ MacOS
   - 🟨 Android (can render normally, but touch input needs to be implemented)
-  - ❌ WebGL (how run a "dll" in WebGL?)
+  - ❌ WebGL (how run a "dll" in WebGL? Maybe Emscripten?)
 - ✅ Docking
 - ✅ Textures
 - ✅ BuiltIn Support
@@ -44,7 +44,7 @@ And some code snippets from the archived [dear-imgui-unity](https://github.com/r
 
 > ✅ - Implemented<br/>
 > 🟨 - Not implemented, but to be done<br/>
-> ❌ - Not implemented, and will not be implemented<br/>
+> ❌ - Not implemented and probably won't be<br/>
  
 ## Samples
 ### Demo Window

--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 ![version tag](https://img.shields.io/badge/version-0.0.1-blue)
 ![dear imgui version tag](https://img.shields.io/badge/DearImGui-1.91.0-orange)
 ![imgui.net version tag](https://img.shields.io/badge/ImGui.Net-1.91.0.1-purple)<br/>
-
+<br/>
+<br/>
 Install from [Package Manager:](https://docs.unity3d.com/Manual/upm-ui-giturl.html)
 ```
 https://github.com/MasterSix997/UBImGui.git
 ```
+
+> [!NOTE]\
+> **`No initial configuration is required`, not even prefabs, or render pipeline passes.<br/>**
+> Everything starts automatically, but you can configure some features in "Edit/Project Settings/UB ImGui"
+
 ## Description
 UB ImGui is an integration between "Unity" and [Dear ImGui](https://github.com/ocornut/imgui), without resource bloat, making it easy to modify and extend. <br/>
 Using the binds provided by [ImGui.Net](https://github.com/ImGuiNET/ImGui.NET) which in turn uses the binds from [cimgui](https://github.com/cimgui/cimgui).
 And some code snippets from the archived [dear-imgui-unity](https://github.com/realgamessoftware/dear-imgui-unity).<br/>
-
-## Note
-> **`No initial configuration is required`, not even prefabs, or render pipeline passes.<br/>**
-> Everything starts automatically, but you can configure some features in "Edit/Project Settings/UB ImGui"
 
 ## Features
 - Unity Versions 


### PR DESCRIPTION
## Objective
Make UBImGui compatible with previous versions of unity

Unity Versions
- Unity 2019 ❌ (Very old version of C# (7.3) and missing several methods of the Graphics class)
- [ ] Unity 2020
- [ ] Unity 2021
- [ ] Unity 2022 🟨 (Android build not working)
- [x] Unity 6